### PR TITLE
Add emojis to post survey and fix navigation issues

### DIFF
--- a/application/src/lib/components/activities/survey/SurveyOption.svelte
+++ b/application/src/lib/components/activities/survey/SurveyOption.svelte
@@ -1,0 +1,19 @@
+<!--
+ /src/lib/components/activities/survey/SurveyOption.svelte
+ SurveyOption.svelte
+ cml-narrative
+ 
+ Created by Ian Thompson on August 1st 2023
+ icthomp@g.clemson.edu
+ 
+ https://idealab.sites.clemson.edu
+ 
+--->
+<script lang="ts">
+	export let emoji: string;
+	export let response: string;
+</script>
+
+<button class="flex items-center rounded-md focus:bg-white focus:bg-opacity-20" on:click>
+	<span class="mr-5 text-5xl">{emoji}</span>{response}
+</button>

--- a/application/src/routes/training/+page.svelte
+++ b/application/src/routes/training/+page.svelte
@@ -167,7 +167,7 @@
 				speaker={line.speaker}
 				dialog={line.dialog}
 				avatar={line.avatar}
-				on:dialogEvent{handleDialogEvent} />
+				on:dialogEvent={handleDialogEvent} />
 		{/if}
 	</div>
 </Scene>

--- a/application/src/routes/training/post-survey/+page.svelte
+++ b/application/src/routes/training/post-survey/+page.svelte
@@ -11,6 +11,7 @@
 --->
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import SurveyOption from '$lib/components/activities/survey/SurveyOption.svelte';
 	import Tablet from '$lib/components/tablet/Tablet.svelte';
 	import DataService from '$lib/utils/DataService';
 
@@ -99,6 +100,16 @@
 			alert('Please select an option first!');
 		}
 	};
+
+	/**
+	 * This function is called when a SurveyOption is clicked. The proper survey response should be passed in
+	 * as parameter. Then, that response is saved to the current questionsAndResponse object
+	 *
+	 * @param response survey response selection
+	 */
+	const handleSelection = (response: string) => {
+		questionsAndResponse[questionIndex].response = response;
+	};
 </script>
 
 <Tablet>
@@ -108,53 +119,18 @@
 		<div class="hud-red-blue-border w-full">
 			<p class="text-center text-3xl text-white">{questionsAndResponse[questionIndex].question}</p>
 		</div>
-		<div class="hud-red-blue-border flex w-3/4 flex-col space-y-4 p-4">
-			<label class="text-2xl">
-				<input
-					type="radio"
-					name="disagree"
-					id=""
-					class=""
-					bind:group={questionsAndResponse[questionIndex].response}
-					value="Strongly Disagree" />
-				Strongly Disagree
-			</label>
-			<label class="text-2xl">
-				<input
-					type="radio"
-					name="disagree"
-					id=""
-					bind:group={questionsAndResponse[questionIndex].response}
-					value="Disagree" />
-				Disagree
-			</label>
-			<label class="text-2xl">
-				<input
-					type="radio"
-					name="disagree"
-					id=""
-					bind:group={questionsAndResponse[questionIndex].response}
-					value="Neutral" />
-				Neutral
-			</label>
-			<label class="text-2xl">
-				<input
-					type="radio"
-					name="disagree"
-					id=""
-					bind:group={questionsAndResponse[questionIndex].response}
-					value="Agree" />
-				Agree
-			</label>
-			<label class="text-2xl">
-				<input
-					type="radio"
-					name="disagree"
-					id=""
-					bind:group={questionsAndResponse[questionIndex].response}
-					value="Strongly Agree" />
-				Strongly Agree
-			</label>
+		<div class="hud-red-blue-border flex w-3/4 flex-col space-y-4 p-4 text-3xl">
+			<SurveyOption
+				emoji="😃"
+				response="Strongly Agree"
+				on:click={() => handleSelection('Strongly Agree')} />
+			<SurveyOption emoji="🙂" response="Agree" on:click={() => handleSelection('Agree')} />
+			<SurveyOption emoji="😐" response="Neutral" on:click={() => handleSelection('Neutral')} />
+			<SurveyOption emoji="🙁" response="Disagree" on:click={() => handleSelection('Disagree')} />
+			<SurveyOption
+				emoji="☹️"
+				response="Strongly Disagree"
+				on:click={() => handleSelection('Strongly Disagree')} />
 		</div>
 		<div class="flex w-full items-end justify-end">
 			<button


### PR DESCRIPTION
This PR proposes changes to:

1. Add emojis to the post-survey
2. Reorder answer selections for post-survey
3. Fix issue #15, where arrows do not allow for navigation in the training sequence 